### PR TITLE
Re-enable filenames with spaces

### DIFF
--- a/dataverse_pooch/__init__.py
+++ b/dataverse_pooch/__init__.py
@@ -48,14 +48,7 @@ def create(server=None, doi=None, **pooch_args):
 
     # Traverse the individual files
     for filedata in metadata["data"]["latestVersion"]["files"]:
-        # Whitespace in filenames does not work with pooch
         filename = filedata["dataFile"]["filename"]
-        if " " in filename:
-            print(
-                f"Skipping file {filename} because of spaces in file name (not supported by pooch)"
-            )
-            continue
-
         filehash = f"md5:{filedata['dataFile']['md5']}"
         fileurl = server._replace(
             path="/api/access/datafile/:persistentId",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dataverse_pooch"
-version = "0.1.0"
+version = "0.1.1"
 description = "Create pooch registry files from DataVerse repositories"
 readme = "README.md"
 maintainers = [

--- a/test/test_dataverse_pooch.py
+++ b/test/test_dataverse_pooch.py
@@ -8,3 +8,6 @@ def test_heidata():
     )
 
     assert os.path.exists(nakadake.fetch("nkd_fpl_slope_LT.json"))
+
+    # Also assert a filename with a space
+    assert os.path.exists(nakadake.fetch("How To - Minimal Workflow.pdf"))


### PR DESCRIPTION
Actually, the limitation only arises when using registry.txt files,
not when programmatically constructing the registry dict.